### PR TITLE
Support gcc non C99

### DIFF
--- a/archive/Archive.c
+++ b/archive/Archive.c
@@ -21,7 +21,8 @@ void        Archive_free(Archive*                 self)
 {
     // free all pages
     size_t n_pages = self->n_pages;
-    for (size_t i = 0; i < n_pages; i++) {
+    size_t i;
+    for (i = 0; i < n_pages; i++) {
         ArchivePage_free(&(self->pages[i]));
     }
     free(self->pages);
@@ -56,9 +57,9 @@ Errors      Archive_save(const Archive*           self,
     
     // alloc a number of ArchiveSaveFile
     result->files = (ArchiveSaveFile*)malloc(sizeof(ArchiveSaveFile) * n_pages);
-
+    size_t i;
     // save all pages
-    for (size_t i = 0; i < n_pages; i++) {
+    for (i = 0; i < n_pages; i++) {
         page = self->pages + i;
         file = result->files + i;
         has_changes = page->has_changes;
@@ -139,7 +140,8 @@ bool                Archive_has_partial(const Archive*      self,
                                         size_t              partial_key_len,
                                         char*               key)
 {
-    for (long long i = self->n_pages - 1; i >= 0; i--) {
+    long long i;
+    for (i = self->n_pages - 1; i >= 0; i--) {
         if (ArchivePage_has(self->pages + i, partial_key, partial_key_len, key)) {
             return true;
         }
@@ -157,8 +159,8 @@ Errors              Archive_get_partial(const Archive*      self,
                                         size_t*             _data_size)
 {
     Errors error;
-    
-    for (long long i = self->n_pages - 1; i >= 0; i--) {
+    long long i;
+    for (i = self->n_pages - 1; i >= 0; i--) {
         // lookup in an archive
         error = ArchivePage_get(self->pages + i, partial_key, partial_key_len, key, data_max_size, _data, _data_size);
         // if success or an error that isn't "not found" stop

--- a/archive/ArchiveSaveResult.h
+++ b/archive/ArchiveSaveResult.h
@@ -19,7 +19,8 @@ static inline void ArchiveSaveResult_free(ArchiveSaveResult*	result)
 {
     ArchiveSaveFile* file;
     size_t count = result->count;
-    for (size_t i = 0; i < count; i++) {
+    size_t i;
+    for (i = 0; i < count; i++) {
         file = &(result->files[i]);
         free(file->filename);
     }
@@ -33,7 +34,8 @@ static inline void ArchiveSaveResult_print(ArchiveSaveResult*	result)
 {
     ArchiveSaveFile* file;
     size_t count = result->count;
-    for (int i = 0; i < count; i++) {
+    int i;
+    for (i = 0; i < count; i++) {
         file = &(result->files[i]);
         printf("Archive file [%s] = %s\n", (file->has_changes ? " changed " : "no change"), file->filename);
     }

--- a/archive/HashIndex.c
+++ b/archive/HashIndex.c
@@ -71,7 +71,8 @@ static inline const HashItem* _HashPage_get(HashPage*       self,
 {
     size_t n_items = self->n_items;
     HashItem *item = self->items;
-    for (int i = 0; i < n_items; ++i) {
+    int i;
+    for (i = 0; i < n_items; ++i) {
         char* item_key = item->key;
         // the first byte doesn't need to be compared as it's in the hash key
         // the two first bytes are compared inline here to reduce the use of
@@ -149,7 +150,8 @@ void      HashIndex_init(HashIndex*                   self)
 void      HashIndex_free(HashIndex*                   self)
 {
     HashPage* page;
-    for (int i = 0; i < HashIndexPageCount; ++i) {
+    int i;
+    for (i = 0; i < HashIndexPageCount; ++i) {
         page = &(self->pages[i]);
         if (page->items != NULL) {
             _HashPage_free(page);

--- a/archive/main.c
+++ b/archive/main.c
@@ -45,7 +45,8 @@ Errors _set_data_n(Archive* archive, size_t n_items, char** _keys)
 {
     Errors error;
     char* keys = (char*)malloc(sizeof(char) * 20 * n_items);
-    for (int i = 0; i < n_items; i++) {
+    int i;
+    for (i = 0; i < n_items; i++) {
         error = _set_data(archive, keys + (20 * i), i);
         if (error != E_SUCCESS) {
             free(keys);
@@ -99,7 +100,8 @@ static inline Errors _read_key_partial(Archive* archive, const char* partial_key
 Errors _check_archive_has_invalid_keys(Archive* archive, size_t n_items)
 {
     char key[20];
-    for (int i = 0; i < 100000; i++) {
+    int i;
+    for (i = 0; i < 100000; i++) {
         rand_key(key);
         if (Archive_has(archive, key)) {
             printf("Failed on has() invalid key (shouldn't have been found), i = %d\n", i);
@@ -112,7 +114,8 @@ Errors _check_archive_has_invalid_keys(Archive* archive, size_t n_items)
 Errors _check_archive_has_invalid_keys_partial(Archive* archive, size_t n_items)
 {
     char partial_key[20];
-    for (int i = 0; i < 100000; i++) {
+    int i;
+    for (i = 0; i < 100000; i++) {
         rand_key(partial_key);
         if (Archive_has_partial(archive, partial_key, 12, NULL)) {
             printf("Failed on has() invalid key (shouldn't have been found), i = %d\n", i);
@@ -124,7 +127,8 @@ Errors _check_archive_has_invalid_keys_partial(Archive* archive, size_t n_items)
 
 Errors _check_archive_has_dynamic_keys(Archive* archive, char* keys, size_t n_items)
 {
-    for (int i = 0; i < n_items; i++) {
+    int i;
+    for (i = 0; i < n_items; i++) {
         char* key = keys + (20 * i);
         if (!Archive_has(archive, key)) {
             printf("Failed on has() dynamic key (not found), i = %d\n", i);
@@ -141,7 +145,8 @@ Errors _check_archive_get_dynamic_keys(Archive* archive, char* keys, size_t n_it
     char value[256];
     char* data;
     size_t data_size;
-    for (int i = 0; i < n_items; i++) {
+    int i;
+    for (i = 0; i < n_items; i++) {
         key = keys + (20 * i);
         error = Archive_get(archive, key, &data, &data_size);
         if (error != E_SUCCESS) {
@@ -167,7 +172,8 @@ Errors _check_archive_get_dynamic_keys_partial(Archive* archive, char* keys, siz
     char value[256];
     char* data;
     size_t data_size;
-    for (int i = 0; i < n_items; i++) {
+    int i;
+    for (i = 0; i < n_items; i++) {
         // get full key
         key = keys + (20 * i);
         
@@ -356,7 +362,8 @@ Errors _build_archive(char** _filenames, size_t* _n_files, char** _keys, size_t 
     
     // copy archive names
     char* new_filenames = malloc(sizeof(char) * 256 * result.count);
-    for (int i = 0; i < result.count; i++) {
+    int i;
+    for (i = 0; i < result.count; i++) {
         strcpy(new_filenames + (256 * i), result.files[i].filename);
     }
     *_filenames = new_filenames;
@@ -377,7 +384,8 @@ Errors _read_archive(char* filenames, size_t n_files, char* keys, size_t n_items
     Archive_init(&archive, "./");
     
     // add pages
-    for (int i = 0; i < n_files; i++) {
+    int i;
+    for (i = 0; i < n_files; i++) {
         char* filename = filenames + (256 * i);
         printf("Add page %s\n", filename);
         error = Archive_add_page_by_name(&archive, filename);


### PR DESCRIPTION
GCC when called from python sometimes runs in non c99 mode lets support both c99 and non c99